### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,6 @@
   "labels": [
     "dependencies"
   ],
-  "helm-requirements": {
-    "fileMatch": [
-      "\\Chart.yaml|requirements.yaml$"
-    ],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-    }
-  },
   "extends": [
     "local>hmcts/.github:renovate-config"
   ]

--- a/renovate.json.bak
+++ b/renovate.json.bak
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": [
+    "dependencies"
+  ],
+  "helm-requirements": {
+    "fileMatch": [
+      "\\Chart.yaml|requirements.yaml$"
+    ],
+    "aliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  },
+  "extends": [
+    "local>hmcts/.github:renovate-config"
+  ]
+}


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.